### PR TITLE
fix: resolve deprecated loop syntax warning

### DIFF
--- a/src/chalk.mbt
+++ b/src/chalk.mbt
@@ -25,12 +25,11 @@ pub fn color(self : Chalk, color : Colors) -> Chalk {
 }
 
 ///|
-pub fn render[T : Show](self : Chalk, to_render : T) -> String {
+pub fn[T : Show] render(self : Chalk, to_render : T) -> String {
   loop to_render.to_string(), self {
     s, Cons(chalk, now_render) =>
       continue match now_render {
-          RenderColor(color) =>
-            "\u001B[\{color_to_index(color)}m\{s}\u001B[39m"
+          RenderColor(color) => "\u001B[\{color_to_index(color)}m\{s}\u001B[39m"
           RenderBackGround(color) =>
             "\u001B[\{background_color_to_index(color)}m\{s}\u001B[49m"
           RenderModifier(modifier) => {

--- a/src/chalk.mbt
+++ b/src/chalk.mbt
@@ -26,18 +26,21 @@ pub fn color(self : Chalk, color : Colors) -> Chalk {
 
 ///|
 pub fn[T : Show] render(self : Chalk, to_render : T) -> String {
-  loop to_render.to_string(), self {
-    s, Cons(chalk, now_render) =>
-      continue match now_render {
-          RenderColor(color) => "\u001B[\{color_to_index(color)}m\{s}\u001B[39m"
-          RenderBackGround(color) =>
-            "\u001B[\{background_color_to_index(color)}m\{s}\u001B[49m"
-          RenderModifier(modifier) => {
-            let (start_idx, end_idx) = modifier_to_index(modifier)
-            "\u001B[\{start_idx}m\{s}\u001B[\{end_idx}m"
-          }
-        },
-        chalk
-    s, Nil => s
+  loop (to_render.to_string(), self) {
+    (s, Cons(chalk, now_render)) =>
+      continue (
+          match now_render {
+            RenderColor(color) =>
+              "\u001B[\{color_to_index(color)}m\{s}\u001B[39m"
+            RenderBackGround(color) =>
+              "\u001B[\{background_color_to_index(color)}m\{s}\u001B[49m"
+            RenderModifier(modifier) => {
+              let (start_idx, end_idx) = modifier_to_index(modifier)
+              "\u001B[\{start_idx}m\{s}\u001B[\{end_idx}m"
+            }
+          },
+          chalk,
+        )
+    (s, Nil) => s
   }
 }

--- a/src/moonbit-chalk.mbti
+++ b/src/moonbit-chalk.mbti
@@ -1,7 +1,10 @@
-package Lampese/moonbit-chalk
+// Generated using `moon info`, DON'T EDIT IT
+package "Lampese/moonbit-chalk"
 
 // Values
 fn chalk() -> Chalk
+
+// Errors
 
 // Types and methods
 pub(all) enum BackGroundColors {
@@ -27,12 +30,10 @@ pub(all) enum Chalk {
   Cons(Chalk, Render)
   Nil
 }
-impl Chalk {
-  background(Self, BackGroundColors) -> Self
-  color(Self, Colors) -> Self
-  modifier(Self, Modifier) -> Self
-  render[T : Show](Self, T) -> String
-}
+fn Chalk::background(Self, BackGroundColors) -> Self
+fn Chalk::color(Self, Colors) -> Self
+fn Chalk::modifier(Self, Modifier) -> Self
+fn[T : Show] Chalk::render(Self, T) -> String
 
 pub(all) enum Colors {
   Black


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

Fixed deprecated loop syntax in src/chalk.mbt by updating from
`loop a, b { ... }` to `loop (a, b) { ... }` and adjusting the
corresponding pattern matching and continue statements to work with
the tuple syntax.

This resolves the compiler warning:
warning[0027]: The syntax loop a, b { ... } for loop with multiple 
arguments is deprecated. Use loop (a, b) { ... } instead.